### PR TITLE
Add hooks for goreleaser and sorting the spelling file

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,7 +1,11 @@
 {
   "default": true,
-  "first-header-h1": false,
-  "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD014": false,
+  "MD033": false,
+  "MD040": false,
+  "MD046": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v3.1.0
     hooks:
       - id: check-json
       - id: check-yaml
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.17.0
+    rev: v0.23.1
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md
 
   - repo: git://github.com/trussworks/pre-commit-hooks
-    rev: v0.0.1
+    rev: v0.0.3
     hooks:
       - id: markdown-toc
       - id: mdspell

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,6 +16,14 @@
   types: ["file", "markdown"]
   pass_filenames: false
 
+- id: goreleaser-check
+  name: Validate goreleaser config yaml
+  description: Validate goreleaser config yaml
+  entry: goreleaser check
+  language: system
+  files: '.goreleaser.yml'
+  pass_filenames: false
+
 - id: markdown-toc
   name: Generate a Table of Contents in Markdown files
   description: Generate a Table of Contents in Markdown files
@@ -31,3 +39,10 @@
   args: ["--ignore-numbers", "--ignore-acronyms", "--en-us", "-r"]
   additional_dependencies: ["markdown-spellcheck"]
   types: ["file", "markdown"]
+
+- id: spelling-sort
+  name: Sort spelling doc
+  description: Sort mdspell spelling file
+  entry: /usr/bin/sort -u -o .spelling .spelling
+  language: script
+  pass_filenames: false

--- a/.spelling
+++ b/.spelling
@@ -2,6 +2,8 @@ CircleCI
 adr-log
 circleci-validate
 config
+goreleaser
+goreleaser-check
 markdown-toc
 mdspell
 pre-commit

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 * [circleci-validate](#circleci-validate)
 * [gen-docs](#gen-docs)
+* [goreleaser-check](#goreleaser-check)
 * [markdown-toc](#markdown-toc)
 * [mdspell](#mdspell)
+* [spelling-sort](#spelling-sort)
 
 Regenerate with "pre-commit run -a markdown-toc"
 
@@ -31,6 +33,15 @@ per the docs on that module.
 By default it will only look in the `docs/` directory of your repo. You can pass in different directories by using
 the `args` parameter like this: `args: ["docs/adr", "docs/rfc"]`
 
+## goreleaser-check
+
+Validate goreleaser config yaml located at `.goreleaser.yml`. In order for this to run you will need to install
+the `goreleaser` CLI tool locally with:
+
+```sh
+brew install goreleaser
+```
+
 ## markdown-toc
 
 Generate a Table of Contents using [markdown-toc](https://www.npmjs.com/package/markdown-toc). It will modify files
@@ -40,3 +51,7 @@ with comments in it per the docs on that module.
 
 Run spellcheck on markdown files using [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck). It
 will ignore words listed in a `.spelling` file in your repo.
+
+## spelling-sort
+
+Run `sort` on the `.spelling` file used by the `markdown-spellcheck` tool. This keeps the file tidy as it is used.


### PR DESCRIPTION
Add new pre-commit hooks:

- goreleaser-check validates the `.gorelease.yml` file
- spelling-sort will sort the `.spelling` file used by `mdspell` hook.

Also updated the pre-commit hooks in the repo and the markdownlint file.

Try it out new hooks from another repo with:

```sh
pre-commit try-repo ../path/to/pre-commit-hooks goreleaser-check
pre-commit try-repo ../path/to/pre-commit-hooks spelling-sort
```

The release for this is to tag it at `v0.0.4`. Then we can use this in the new CLI tools that use goreleaser.