### PR TITLE
Upgrade pre-commit hooks to get new spelling-sort hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,8 @@ repos:
         entry: markdownlint --ignore .github/*.md
 
   - repo: git://github.com/trussworks/pre-commit-hooks
-    rev: v0.0.3
+    rev: v0.0.4
     hooks:
       - id: markdown-toc
       - id: mdspell
+      - id: spelling-sort


### PR DESCRIPTION
Fast on the heels of https://github.com/trussworks/pre-commit-hooks/pull/3 this updates this repo to use the new hooks!