### PR TITLE
Specify markdown-toc as a dependency  …

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -27,9 +27,10 @@
 - id: markdown-toc
   name: Generate a Table of Contents in Markdown files
   description: Generate a Table of Contents in Markdown files
-  entry: npx md-toc
+  entry: markdowntoc
   language: node
   types: ["file", "markdown"]
+  additional_dependencies: ["markdown-toc"]
 
 - id: mdspell
   name: Run spellcheck

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "name": "pre-commit-hooks",
   "private": true,
   "bin": {
-    "md-toc": "./pre-commit-markdown-toc",
+    "markdowntoc": "./pre-commit-markdown-toc",
     "adr": "./pre-commit-gen-docs"
   },
   "scripts": {},

--- a/pre-commit-markdown-toc
+++ b/pre-commit-markdown-toc
@@ -9,16 +9,12 @@
 
 set -eu -o pipefail
 
-# Get the directory of this file inside pre-commit cache
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-MDTOC_BIN="${DIR}/../../node_modules/.bin/markdown-toc"
-
 for filename in "$@"; do
   # Using backticks in this appended comment seems to make the script
   # indicated run after a 3/5 update to markdown-toc 1.2.0;
   # stick with quotes for now.
   regen=$'\n\n<!-- Regenerate with "pre-commit run -a markdown-toc" -->'
 
-  node "${MDTOC_BIN}" --bullets='*' --append="${regen}" -i "${filename}"
+  markdown-toc --bullets='*' --append="${regen}" -i "${filename}"
   # yarn run --silent markdown-toc --bullets='*' --append="${regen}" -i "${filename}"
 done


### PR DESCRIPTION
Previously, the `entry` for the markdown-toc hook was `npx md-toc`,
which was meant to call the `pre-commmit-markdown-toc` script, via the
mapping in the `bin` section of `package.json`. The script then looked
for the `markdown-toc` executable in the
`~/.cache/pre-commit/{reponame}/node_modules/.bin/markdown-toc`
directory, but would return an error because it couldn't find it. It
doesn't get automatically installed there, even when specified as an
additional dependency.

To add to the confusion, if you had the `md-toc` package installed
locally, that's what would be called instead of the
`pre-commmit-markdown-toc` script, which made the error go away, but
wouldn't actually generate a TOC.

The solution in 3 steps:

1. Use an `entry` name that doesn't match an existing npm package.
2. Define `markdown-toc` as an additional dependency so that it gets
automatically installed.
3. Instead of looking for the `markdown-toc` executable in the
`pre-commit` directory, just call it directly.

## How to test this fix locally

1. Clone this repo
2. run `rm -rf ~/.cache/pre-commit`
3. Make sure `node --version` returns something. If you don't have node installed on your computer, install it with brew, or nodenv, or whatever you like.
4. Add the following at the end of this repo's `README.md` and save the file:
```markdown
## Another section

hello
```
5. run `git add .` followed by `git commit -m "testing"`
You should get an error about the markdown-toc module not being found
6. Run `rm -rf ~/.cache/pre-commit`
7. Open up `pre-commit-config.yaml` in this repo and replace `v1.0.0` in the `trussworks/pre-commit-hooks` section with `7ce2b9918ba70d3efef6145ae45e561809bcafbe` (the commit hash for this PR)
8. Save the file
9. run `git add .` and `git commit -m "testing"`
- [x] Verify that you don't see any errors and that the table of contents in the README is updated

