### PR TITLE
Add hadolint hook that downloads binary on run

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -47,3 +47,9 @@
   entry: /usr/bin/sort -u -o .spelling .spelling
   language: script
   pass_filenames: false
+
+- id: hadolint
+  name: Run hadolint Dockerfile linter
+  description: Run hadolint Dockerfile linter
+  entry: pre-commit-hadolint
+  language: script

--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ will ignore words listed in a `.spelling` file in your repo.
 ## spelling-sort
 
 Run `sort` on the `.spelling` file used by the `markdown-spellcheck` tool. This keeps the file tidy as it is used.
+
+## hadolint
+
+Run the [hadolint](https://github.com/hadolint/hadolint) Dockerfile linter

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -34,3 +34,6 @@ done
 if [[ "${#files[@]}" -gt 0 ]]; then
     exec "${LOCAL_BINARY}" "${files[@]}"
 fi
+
+# if no files, exit successfully
+exit 0

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+HADOLINT_PREFIX_URL="https://github.com/hadolint/hadolint/releases/download"
+HADOLINT_VERSION="v2.1.0"
+OS=$(uname -s)
+ARCH=$(uname -m)
+HADOLINT_BINARY="hadolint-${OS}-${ARCH}"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+LOCAL_BINARY="${DIR}/${HADOLINT_BINARY}-${HADOLINT_VERSION}"
+
+# Download the binary if it doesn't already exist
+if [[ ! -x ${LOCAL_BINARY} ]]; then
+    curl -o "${LOCAL_BINARY}" \
+         -L -sSf "${HADOLINT_PREFIX_URL}/${HADOLINT_VERSION}/${HADOLINT_BINARY}"
+    chmod 755 "${LOCAL_BINARY}"
+fi
+
+files=()
+
+# only run hadolint if it looks like a Dockerfile
+for f in "$@"; do
+    case $f in
+        (Dockerfile*|*/Dockerfile*)
+            files+=( "${f}" )
+            ;;
+    esac
+done
+
+if [[ "${#files[@]}" -gt 0 ]]; then
+    exec "${LOCAL_BINARY}" "${files[@]}"
+fi

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -13,15 +13,11 @@ LOCAL_BINARY="${DIR}/${HADOLINT_BINARY}-${HADOLINT_VERSION}"
 
 # Download the binary if it doesn't already exist
 if [[ ! -x ${LOCAL_BINARY} ]]; then
-    curl -o "${LOCAL_BINARY}" \
+    # download to temp location and rename to prevent Text file busy
+    curl -o "${LOCAL_BINARY}.new" \
          -L -sSf "${HADOLINT_PREFIX_URL}/${HADOLINT_VERSION}/${HADOLINT_BINARY}"
-    chmod 755 "${LOCAL_BINARY}"
-    if [[ -n "${CIRCLECI+x}" ]]; then
-        # oh CircleCI, you so funny
-        # Text file busy error makes is likely you are using aufs and
-        # so we need to
-        sync
-    fi
+    chmod 755 "${LOCAL_BINARY}.new"
+    mv "${LOCAL_BINARY}.new" "${LOCAL_BINARY}"
 fi
 
 files=()

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -13,11 +13,14 @@ LOCAL_BINARY="${DIR}/${HADOLINT_BINARY}-${HADOLINT_VERSION}"
 
 # Download the binary if it doesn't already exist
 if [[ ! -x ${LOCAL_BINARY} ]]; then
+    tmp_local_binary="${LOCAL_BINARY}.new"
     # download to temp location and rename to prevent Text file busy
-    curl -o "${LOCAL_BINARY}.new" \
+    curl -o "${tmp_local_binary}" \
          -L -sSf "${HADOLINT_PREFIX_URL}/${HADOLINT_VERSION}/${HADOLINT_BINARY}"
-    chmod 755 "${LOCAL_BINARY}.new"
-    mv "${LOCAL_BINARY}.new" "${LOCAL_BINARY}"
+    # ensure the file is synced on CIRCLECI
+    [ -n "${CIRCLECI+x}" ] && sync
+    chmod 755 "${tmp_local_binary}"
+    mv "${tmp_local_binary}" "${LOCAL_BINARY}"
 fi
 
 files=()

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -24,6 +24,7 @@ function mylock() {
 }
 
 # Download the binary if it doesn't already exist
+# use the locking pattern from https://linux.die.net/man/1/flock
 (
     mylock
     if [[ ! -x ${LOCAL_BINARY} ]]; then

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -12,18 +12,25 @@ HADOLINT_URL="${HADOLINT_PREFIX_URL}/${HADOLINT_VERSION}/${HADOLINT_BINARY}"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 LOCAL_BINARY="${DIR}/${HADOLINT_BINARY}-${HADOLINT_VERSION}"
 
+function mylock() {
+    # *sigh*
+    # macOS does not have flock so fall back to perl(!) if it's not
+    # available
+    if command -v flock &>/dev/null; then
+        flock -x 200
+    else
+        perl -e 'use Fcntl qw(:flock); open($fh, "<&=", 200) || die "Cannot open"; flock($fh, LOCK_EX) || die "Cannot lock"'
+    fi
+}
+
 # Download the binary if it doesn't already exist
-if [[ ! -x ${LOCAL_BINARY} ]]; then
-    # use mkdir as a lock so only single download happens
-    # can't use flock as that doesn't exist on macOS
-    if mkdir "${LOCAL_BINARY}.lock" 2>/dev/null; then
+(
+    mylock
+    if [[ ! -x ${LOCAL_BINARY} ]]; then
         curl -o "${LOCAL_BINARY}" -L -sSf "${HADOLINT_URL}"
         chmod 755 "${LOCAL_BINARY}"
-    else
-        # another process is downloading, give it time to complete
-        sleep 5
     fi
-fi
+) 200> "${LOCAL_BINARY}.lock"
 
 files=()
 

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -7,20 +7,22 @@ HADOLINT_VERSION="v2.1.0"
 OS=$(uname -s)
 ARCH=$(uname -m)
 HADOLINT_BINARY="hadolint-${OS}-${ARCH}"
+HADOLINT_URL="${HADOLINT_PREFIX_URL}/${HADOLINT_VERSION}/${HADOLINT_BINARY}"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 LOCAL_BINARY="${DIR}/${HADOLINT_BINARY}-${HADOLINT_VERSION}"
 
 # Download the binary if it doesn't already exist
 if [[ ! -x ${LOCAL_BINARY} ]]; then
-    tmp_local_binary="${LOCAL_BINARY}.new"
-    # download to temp location and rename to prevent Text file busy
-    curl -o "${tmp_local_binary}" \
-         -L -sSf "${HADOLINT_PREFIX_URL}/${HADOLINT_VERSION}/${HADOLINT_BINARY}"
-    # ensure the file is synced on CIRCLECI
-    [ -n "${CIRCLECI+x}" ] && sync
-    chmod 755 "${tmp_local_binary}"
-    mv "${tmp_local_binary}" "${LOCAL_BINARY}"
+    # use mkdir as a lock so only single download happens
+    # can't use flock as that doesn't exist on macOS
+    if mkdir "${LOCAL_BINARY}.lock" 2>/dev/null; then
+        curl -o "${LOCAL_BINARY}" -L -sSf "${HADOLINT_URL}"
+        chmod 755 "${LOCAL_BINARY}"
+    else
+        # another process is downloading, give it time to complete
+        sleep 5
+    fi
 fi
 
 files=()

--- a/pre-commit-hadolint
+++ b/pre-commit-hadolint
@@ -16,6 +16,12 @@ if [[ ! -x ${LOCAL_BINARY} ]]; then
     curl -o "${LOCAL_BINARY}" \
          -L -sSf "${HADOLINT_PREFIX_URL}/${HADOLINT_VERSION}/${HADOLINT_BINARY}"
     chmod 755 "${LOCAL_BINARY}"
+    if [[ -n "${CIRCLECI+x}" ]]; then
+        # oh CircleCI, you so funny
+        # Text file busy error makes is likely you are using aufs and
+        # so we need to
+        sync
+    fi
 fi
 
 files=()


### PR DESCRIPTION
Instead of using the system hadolint or trying to run inside docker, download the binary on run so pre-commit installs everything needed and we control the version of hadolint
