### PR TITLE
Overhaul renovate.json and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,16 +11,20 @@ repos:
       - id: mixed-line-ending
       - id: check-yaml
 
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.34.0
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
     hooks:
-      - id: markdownlint
-        entry: markdownlint --ignore .github/*.md
+      - id: mdformat
+        name: fix markdown formatting with mdformat
+        types: [markdown]
+        additional_dependencies:
+          - mdformat-gfm
+          - mdformat-toc
+          - mdformat-frontmatter
 
   - repo: https://github.com/trussworks/pre-commit-hooks
     rev: v1.1.1
     hooks:
-      - id: markdown-toc
       - id: mdspell
       - id: spelling-sort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,10 @@ repos:
       - id: check-json
       - id: check-yaml
       - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-yaml
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.23.2
@@ -19,3 +23,10 @@ repos:
       - id: markdown-toc
       - id: mdspell
       - id: spelling-sort
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.2
+    hooks:
+      - id: shellcheck
+        name: lint shell scripts with shellcheck
+        types: [shell]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # Truss pre-commit hooks
 
-<!-- toc -->
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=1 -->
 
-* [circleci-validate](#circleci-validate)
-* [gen-docs](#gen-docs)
-* [goreleaser-check](#goreleaser-check)
-* [markdown-toc](#markdown-toc)
-* [mdspell](#mdspell)
-* [spelling-sort](#spelling-sort)
-* [hadolint](#hadolint)
+- [Truss pre-commit hooks](#truss-pre-commit-hooks)
+  - [circleci-validate](#circleci-validate)
+  - [gen-docs](#gen-docs)
+  - [goreleaser-check](#goreleaser-check)
+  - [markdown-toc](#markdown-toc)
+  - [mdspell](#mdspell)
+  - [spelling-sort](#spelling-sort)
+  - [hadolint](#hadolint)
 
-<!-- Regenerate with "pre-commit run -a markdown-toc" -->
-
-<!-- tocstop -->
+<!-- mdformat-toc end -->
 
 ## circleci-validate
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    }
+  ],
+  "pre-commit": {
+    "enabled": true
+  },
+  "separateMinorPatch": false
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Update renovate.json so that hopefully dependencies will get managed
- Add some more useful pre-commit hooks
- Use mdformat instead of markdownlint and markdown-toc
