### PR TITLE
feat: use npx rather than node to invoke adr-log

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 repos:
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -29,7 +28,7 @@ repos:
       - id: spelling-sort
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.2
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck
         name: lint shell scripts with shellcheck

--- a/pre-commit-gen-docs
+++ b/pre-commit-gen-docs
@@ -3,8 +3,8 @@
 set -eu -o pipefail
 
 # Get the directory of this file inside pre-commit cache
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ADR_BIN="${DIR}/../../node_modules/.bin/adr-log"
+#DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+#ADR_BIN="${DIR}/../../node_modules/.bin/adr-log"
 
 # Rename ADR to whatever we want
 function rename {
@@ -20,7 +20,7 @@ function update_index {
   pushd "${dir}" > /dev/null || return
 
   # Rebuild the index && remove both newlines that it adds
-  node "${ADR_BIN}" -i && chomp index.md && chomp index.md
+  npx adr-log -i && chomp index.md && chomp index.md
 
   # We need to rename ADR to a different name
   title=$(basename "$1")


### PR DESCRIPTION
- **chore(deps): update shellcheck-py pre-commit hook**
- **use npx rather than trying to calculate value**

Fixes #10
